### PR TITLE
Potential fix for code scanning alert no. 2: Clear text transmission of sensitive cookie

### DIFF
--- a/app.js
+++ b/app.js
@@ -12,6 +12,7 @@ var indexRouter = require('./routes/index');
 var authRouter = require('./routes/auth');
 
 var app = express();
+app.set('trust proxy', 1);
 
 app.locals.pluralize = require('pluralize');
 
@@ -29,7 +30,12 @@ app.use(session({
   secret: 'keyboard cat',
   resave: false,
   saveUninitialized: false,
-  store: new SQLiteStore({ db: 'sessions.db', dir: './var/db' })
+  store: new SQLiteStore({ db: 'sessions.db', dir: './var/db' }),
+  cookie: {
+    secure: true,
+    httpOnly: true,
+    sameSite: 'lax'
+  }
 }));
 app.use('/', indexRouter);
 app.use('/', authRouter);
@@ -37,7 +43,12 @@ app.use(session({
   secret: 'keyboard cat',
   resave: false,
   saveUninitialized: false,
-  store: new SQLiteStore({ db: 'sessions.db', dir: './var/db' })
+  store: new SQLiteStore({ db: 'sessions.db', dir: './var/db' }),
+  cookie: {
+    secure: true,
+    httpOnly: true,
+    sameSite: 'lax'
+  }
 }));
 app.use(passport.authenticate('session'));
 // catch 404 and forward to error handler


### PR DESCRIPTION
Potential fix for [https://github.com/Code-lab-web/js-project-movies/security/code-scanning/2](https://github.com/Code-lab-web/js-project-movies/security/code-scanning/2)

In general, to fix this problem you must configure the session cookie to be marked as `secure` (and ideally `httpOnly` and `sameSite`) so that browsers only send it over HTTPS. With `express-session`, this is done by adding a `cookie` configuration object to the session options, e.g. `cookie: { secure: true, httpOnly: true }`, and ensuring the app is actually served over HTTPS (or behind a TLS‑terminating proxy with `app.set('trust proxy', 1)`).

For this specific file, the best fix that preserves existing functionality is:
- Add `app.set('trust proxy', 1);` after `var app = express();` so that, when behind a reverse proxy that terminates TLS, `express-session` can rely on the `X-Forwarded-Proto` header to determine HTTPS.
- Update both `app.use(session({ ... }))` calls (lines 28–33 and 36–41) to include a `cookie` option with `secure: true`, `httpOnly: true`, and a sensible `sameSite` setting (e.g. `'lax'`). This ensures the session cookie is only sent over HTTPS, is not accessible to JavaScript, and has CSRF‑mitigation semantics, without changing how sessions otherwise behave.
- No new imports are needed; all changes are within `app.js` in the shown regions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
