### PR TITLE
Potential fix for code scanning alert no. 3: Clear text transmission of sensitive cookie

### DIFF
--- a/app.js
+++ b/app.js
@@ -13,6 +13,9 @@ var authRouter = require('./routes/auth');
 
 var app = express();
 
+// trust first proxy so secure cookies work correctly behind HTTPS proxies
+app.set('trust proxy', 1);
+
 app.locals.pluralize = require('pluralize');
 
 // view engine setup
@@ -29,7 +32,12 @@ app.use(session({
   secret: 'keyboard cat',
   resave: false,
   saveUninitialized: false,
-  store: new SQLiteStore({ db: 'sessions.db', dir: './var/db' })
+  store: new SQLiteStore({ db: 'sessions.db', dir: './var/db' }),
+  cookie: {
+    secure: true,
+    httpOnly: true,
+    sameSite: 'lax'
+  }
 }));
 app.use('/', indexRouter);
 app.use('/', authRouter);
@@ -37,7 +45,12 @@ app.use(session({
   secret: 'keyboard cat',
   resave: false,
   saveUninitialized: false,
-  store: new SQLiteStore({ db: 'sessions.db', dir: './var/db' })
+  store: new SQLiteStore({ db: 'sessions.db', dir: './var/db' }),
+  cookie: {
+    secure: true,
+    httpOnly: true,
+    sameSite: 'lax'
+  }
 }));
 app.use(passport.authenticate('session'));
 // catch 404 and forward to error handler


### PR DESCRIPTION
Potential fix for [https://github.com/Code-lab-web/js-project-movies/security/code-scanning/3](https://github.com/Code-lab-web/js-project-movies/security/code-scanning/3)

In general, to fix this problem you must configure the session cookie to be marked as `secure`, so it is only sent over HTTPS, and ideally also set `httpOnly` (to block access from client-side JavaScript) and `sameSite` (to mitigate CSRF). With `express-session`, this is done via the `cookie` option, e.g. `cookie: { secure: true, httpOnly: true, sameSite: 'lax' }`. When the app is behind a TLS-terminating proxy, you typically also enable `trust proxy` so Express can correctly determine whether a request is secure.

The best targeted fix here, without changing existing functionality more than necessary, is:

- Add `app.set('trust proxy', 1);` once, shortly after `var app = express();` so that when the app runs behind a proxy, `req.secure` reflects the original HTTPS connection.
- Update both `app.use(session({ ... }))` calls (lines 28–33 and 36–41) to include a `cookie` configuration with `secure: true`, `httpOnly: true`, and `sameSite` (e.g. `'lax'`). This ensures the session cookie is never sent over plain HTTP and is protected from basic script access and CSRF.
- Keep the existing `secret`, `resave`, `saveUninitialized`, and `store` values unchanged.

No extra imports are needed, as `express-session` is already in use.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
